### PR TITLE
fix lora us915 logic to step into 500 kHz range

### DIFF
--- a/lora/lorawan/region/us915.go
+++ b/lora/lorawan/region/us915.go
@@ -32,22 +32,21 @@ func (c *ChannelUS) Next() bool {
 		freq, ok := stepFrequency125(c.frequency)
 		if ok {
 			c.frequency = freq
-			return true
 		} else {
 			c.frequency = lora.Mhz_903_0
-			return true
+			c.bandwidth = lora.Bandwidth_500_0
 		}
 	case lora.Bandwidth_500_0:
 		freq, ok := stepFrequency500(c.frequency)
 		if ok {
 			c.frequency = freq
-			return true
 		} else {
+			// there are no more frequencies to check after sweeping all 8 500 kHz channels
 			return false
 		}
 	}
 
-	return false
+	return true
 }
 
 func stepFrequency125(freq uint32) (uint32, bool) {


### PR DESCRIPTION
Fixes the stepping bug and sweeps fully through all accept channels at 125 and 500 mHz